### PR TITLE
Load `:repo` opt from app config

### DIFF
--- a/lib/swiss_schema.ex
+++ b/lib/swiss_schema.ex
@@ -435,7 +435,11 @@ defmodule SwissSchema do
             ) :: {non_neg_integer(), nil | [term()]}
 
   defmacro __using__(opts) do
-    repo = Keyword.fetch!(opts, :repo)
+    repo =
+      case Application.get_env(:swiss_schema, __MODULE__) do
+        nil -> Keyword.fetch!(opts, :repo)
+        repo -> repo
+      end
 
     quote do
       @behaviour SwissSchema

--- a/test/swiss_schema_test.exs
+++ b/test/swiss_schema_test.exs
@@ -1,5 +1,5 @@
 defmodule SwissSchemaTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   alias SwissSchemaTest.Repo
   alias SwissSchemaTest.Repo2
   alias SwissSchemaTest.User
@@ -35,12 +35,26 @@ defmodule SwissSchemaTest do
 
   describe "use SwissSchema" do
     test "requires a :repo option" do
+      Application.put_env(:swiss_schema, SwissSchema, nil)
+
       assert_raise KeyError, fn ->
         defmodule SwissSchemaTest.BadSchema do
           use Ecto.Schema
           use SwissSchema
         end
       end
+    end
+
+    test "load :repo option from default app config" do
+      Application.put_env(:swiss_schema, SwissSchema, Repo, persistent: false)
+
+      defmodule CustomSchema do
+        use Ecto.Schema
+        use SwissSchema
+      end
+
+      assert function_exported?(CustomSchema, :aggregate, 1)
+      assert function_exported?(CustomSchema, :aggregate, 2)
     end
 
     test "define aggregate/1" do


### PR DESCRIPTION
The `repo` option for `SwissSchema` is now loaded from `config.exs` If not found, it get the option from opts parameter, like before.

See #18 